### PR TITLE
expose disconnecting

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -264,6 +264,16 @@ Client.prototype.isConnected = function() {
 };
 
 /**
+ * Whether or not we are currently disconnecting. 
+ *
+ * @return {boolean} - Whether we are disconnected.
+ */
+Client.prototype.isDisconnecting = function() {
+  return !!(this._isDisconnecting && this._client);
+};
+
+
+/**
  * Get the last error emitted if it exists.
  *
  * @return {LibrdKafkaError} - Returns the LibrdKafkaError or null if


### PR DESCRIPTION
exposes the internal disconnecting. 
nec. for example if you want to use consumer.assignments() during a disconnect window. 
consumer.assignments() would lead to an error if invoked during disconnects.