### PR TITLE
Add support for worker_threads

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -73,7 +73,7 @@ void ConstantsInit(v8::Local<v8::Object> exports) {
     Nan::GetFunction(Nan::New<v8::FunctionTemplate>(NodeRdKafkaBuildInFeatures)).ToLocalChecked());  // NOLINT
 }
 
-void Init(v8::Local<v8::Object> exports, v8::Local<v8::Value> m_, void* v_) {
+void Init(v8::Local<v8::Object> exports) {
 #if NODE_MAJOR_VERSION <= 9 || (NODE_MAJOR_VERSION == 10 && NODE_MINOR_VERSION <= 15)
   AtExit(RdKafkaCleanup);
 #else
@@ -91,4 +91,8 @@ void Init(v8::Local<v8::Object> exports, v8::Local<v8::Value> m_, void* v_) {
       Nan::New(RdKafka::version_str().c_str()).ToLocalChecked());
 }
 
+#if NODE_MAJOR_VERSION >= 10
+NAN_MODULE_WORKER_ENABLED(kafka, Init)
+#else
 NODE_MODULE(kafka, Init)
+#endif

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -91,8 +91,4 @@ void Init(v8::Local<v8::Object> exports) {
       Nan::New(RdKafka::version_str().c_str()).ToLocalChecked());
 }
 
-#if NODE_MAJOR_VERSION >= 10
 NAN_MODULE_WORKER_ENABLED(kafka, Init)
-#else
-NODE_MODULE(kafka, Init)
-#endif

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,3 +6,21 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE.txt file for details.
  */
+
+const worker = require('worker_threads');
+const t = require('assert');
+
+module.exports = {
+  'Node package': {
+    'should not throw an error when module is loaded inside a worker': function() {
+      t.doesNotThrow(function() {
+        new worker.Worker(`
+          const t = require('assert');
+          const { isMainThread } = require('worker_threads');
+          t.strictEqual(isMainThread, false);
+          require("./librdkafka.js");
+        `, { eval: true });
+      });
+    },
+  }
+}


### PR DESCRIPTION
This is port of https://github.com/Blizzard/node-rdkafka/pull/857 by @Twixes, that registers the module with `NAN_MODULE_WORKER_ENABLED`, for compatibility with [worker_threads](https://nodejs.org/api/worker_threads.html).

## Testing

- Existing test coverage confirms the main thread usage is unaffected
- Additional test `test/index.spec.js` confirms that the module is now available in a worker thread

## Compatibility

[nan](https://github.com/nodejs/nan/blob/main/nan.h#L165-L178) transparently falls back to the old API for versions older than 10. I tested it with `node-v8.0.0-darwin-x64` (build and test run fine).

## Do we need cleanup?

Looking at PRs on other libraries, I found that [this one](https://github.com/CharlieHess/node-mac-notifier/pull/32) adds a call to `node::AddEnvironmentCleanupHook` to avoid leaking resources on worker exit. I'll need to check the codebase to see whether it's needed here.
